### PR TITLE
Hides matchmaking

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -96,6 +96,7 @@ class App extends React.Component {
           googleSignOut={ this.googleSignOut }
           googleSignIn={ this.googleSignIn }
           googleUserData={ this.state.googleUserData }
+          playerData={ this.state.playerData }
         />
         <Switch>
           <Route exact path='/' render={ () => {

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -9,7 +9,7 @@ import Profile from './Profile.jsx';
 import Matchmaking from './Matchmaking.jsx';
 import RecommendedMatches from './RecommendedMatches.jsx';
 import Stats from './Stats.jsx';
-import { CHECK_EMAIL_IS_UNIQUE } from '../apollo/queries.js';
+import { CHECK_EMAIL_IS_UNIQUE, GET_USER_BY_EMAIL } from '../apollo/queries.js';
 
 class App extends React.Component {
   constructor(props) {
@@ -24,6 +24,7 @@ class App extends React.Component {
     this.googleSignIn = this.googleSignIn.bind(this);
     this.googleSignOut = this.googleSignOut.bind(this);
     this.mapGoogleDataToProfile = this.mapGoogleDataToProfile.bind(this);
+    this.mapDBPlayerDataToState = this.mapDBPlayerDataToState.bind(this);
   }
 
   componentDidMount() {
@@ -69,15 +70,23 @@ class App extends React.Component {
 
   /* --- ACCOUNT CREATION --- */
   mapGoogleDataToProfile () {
-    return () => {
-      this.setState({
-        userProfile: {
-          fullName: this.state.googleUserData.displayName,
-          email: this.state.googleUserData.email,
-          phoneNumber: this.state.googleUserData.phoneNumber
-        }
-      });
-    };
+    this.setState({
+      userProfile: {
+        fullName: this.state.googleUserData.displayName,
+        email: this.state.googleUserData.email,
+        phoneNumber: this.state.googleUserData.phoneNumber
+      }
+    });
+  }
+
+  mapDBPlayerDataToState ( dbData ) {
+    this.setState({
+      playerData: {
+        elo: dbData.elo,
+        wins: dbData.wins,
+        losses: dbData.losses
+      }
+    });
   }
 
   render () {
@@ -106,7 +115,8 @@ class App extends React.Component {
           <Route path='/signup' render={ () => {
             { if ( this.state.googleUserData ) {
               return (
-                <Query query={ CHECK_EMAIL_IS_UNIQUE }
+                <Query
+                  query={ CHECK_EMAIL_IS_UNIQUE }
                   variables={{ email: this.state.googleUserData.email }}
                   fetchPolicy='no-cache'>
                   {({ loading, error, data }) => {
@@ -129,11 +139,22 @@ class App extends React.Component {
               return null;
             } }
           } } />
-          <Route path='/matchmaking' render={ () => {
-            return <Matchmaking 
-              mapGoogleDataToProfile={ this.mapGoogleDataToProfile }
-              userData={ this.state.googleUserData }/>;
-          } }/>
+          <Route path='/matchmaking' render={ () => (
+            <Query
+              query={ GET_USER_BY_EMAIL }
+              variables={{ email: this.state.googleUserData.email }}>
+              {({ loading, error, data }) => {
+                if ( loading ) { return <p>Loading...</p>; }
+                if ( error ) { return <p>Error! ${ error }</p>; }
+                console.log(data.getUserByEmail);
+                return <Matchmaking
+                  playerData={ data.getUserByEmail } 
+                  mapGoogleDataToProfile={ this.mapGoogleDataToProfile }
+                  mapDBPlayerDataToState={ this.mapDBPlayerDataToState }
+                />;
+              }}
+            </Query>
+          ) }/>
           <Route path='/profile' render={ () => <Profile/> }/>
           <Route path='/stats' render={ () => <Stats/> }/>
         </Switch>

--- a/client/src/components/Matchmaking.jsx
+++ b/client/src/components/Matchmaking.jsx
@@ -17,6 +17,8 @@ class Matchmaking extends React.Component {
 
   componentDidMount () {
     this.props.mapGoogleDataToProfile();
+    this.props.mapDBPlayerDataToState( this.props.playerData );
+    console.log(this.props.test);
   }
 
   render () {

--- a/client/src/components/Matchmaking.jsx
+++ b/client/src/components/Matchmaking.jsx
@@ -18,7 +18,6 @@ class Matchmaking extends React.Component {
   componentDidMount () {
     this.props.mapGoogleDataToProfile();
     this.props.mapDBPlayerDataToState( this.props.playerData );
-    console.log(this.props.test);
   }
 
   render () {

--- a/client/src/components/NavBar.jsx
+++ b/client/src/components/NavBar.jsx
@@ -15,8 +15,8 @@ const NavBar = (props) => {
         <Navbar.Toggle />
       </Navbar.Header>
       <Navbar.Collapse>
-        { !props.googleUserData ?
-          <Nav pullRight>
+        { !props.googleUserData || !props.playerData 
+          ? <Nav pullRight>
             <LinkContainer to='/signup'>
               <NavItem onClick={ props.googleSignIn }>
                 Sign in with Google

--- a/client/src/components/Signup.jsx
+++ b/client/src/components/Signup.jsx
@@ -74,15 +74,14 @@ class Signup extends React.Component {
             </FormGroup>
             <FormGroup>
               <Link to='/matchmaking'>
-                <Mutation 
+                <Mutation
                   mutation={ CREATE_USER }
                   variables={{ email: this.props.googleUserData.email }}>
                   { createUser => (
-                    <Button 
+                    <Button
                       type="submit"
-                      className='pull-right' 
+                      className='pull-right'
                       onClick={ createUser }>
-                      
                       Enter Matchmaking
                     </Button>
                   ) }


### PR DESCRIPTION
User can re-authenticate from the signup page by clicking the google sign-in option again but it doesn't redirect or do anything. This does not prevent manually navigating to /matchmaking. The navbar could be made to display nothing on the signup page with the props that are passed to it now.
closes #223 